### PR TITLE
usage example should use JavaScript syntax highlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or via git:
 Usage
 -----
 
-```
+```js
 // Yeah, Jetty!
 var Jetty = require("jetty");
 


### PR DESCRIPTION
Currently the “Usage” section in `README.md` contains a code block.

This pull request adds a JavaScript language identifier to that block, and thus the code is syntactically highlighted.
